### PR TITLE
Add Retrofit Proguard instructions [MOBILE-1070]

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,37 +26,7 @@
     }
     ```
 
-3. If you use ProGuard, add the following to your `proguard-rules.pro` file:
-
-    ```
-    # Retrofit
-    # Taken from https://square.github.io/retrofit/
-    -dontnote retrofit2.Platform
-    -dontnote retrofit2.Platform$IOS$MainThreadExecutor
-    -dontwarn retrofit2.Platform$Java8
-    -keepattributes Signature
-    -keepattributes Exceptions
-    -keepclasseswithmembers class * {
-        @retrofit2.http.* <methods>;
-    }
-
-    # OkHttp
-    -dontwarn com.squareup.okhttp.**
-    -dontwarn okio.Okio
-    -dontwarn okio.DeflaterSink
-    -dontwarn java.nio.file.*
-    -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
-
-    # Placed
-    -keep class com.placed.client.android.DTOModel {
-        *;
-    }
-    -keep class * extends com.placed.client.android.DTOModel {
-        <fields>;
-    }
-    ```
-
-4. You may encounter Lint error: 'InvalidPackage: Package not included in Android' related to Okio and Retrofit. (This is a known issue with Okio that you can read about [here](https://github.com/square/okio/issues/58).)
+3. You may encounter Lint error: 'InvalidPackage: Package not included in Android' related to Okio and Retrofit. (This is a known issue with Okio that you can read about [here](https://github.com/square/okio/issues/58).)
 
     If so, create a `lint.xml` with the following contents:
     ```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,28 @@
         <fields>;
     }
     ```
+
+4. You may encounter Lint error: 'InvalidPackage: Package not included in Android' related to Okio and Retrofit. (This is a known issue with Okio that you can read about [here](https://github.com/square/okio/issues/58).)
+
+    If so, create a `lint.xml` with the following contents:
+    ```
+    <lint>
+        <issue id="InvalidPackage">
+            <ignore regexp=".*okio.*" />
+            <ignore regexp=".*retrofit.*" />
+        </issue>
+    </lint>
+    ```
+
+    And reference it from your **app** `build.gradle` file:
+    ```
+    android {
+        ...
+        lintOptions {
+            lintConfig file("lint.xml")
+        }
+    }
+    ```
   
 ### Configuration
 * Add the application key provided to you by Placed in the application tag of your **AndroidManifest.xml**.

--- a/README.md
+++ b/README.md
@@ -6,25 +6,55 @@
 
 1. Add the following to your **root** `build.gradle` file:
 
-```
-allprojects {
-    repositories {
-        ...
+    ```
+    allprojects {
+        repositories {
+            ...
 
-        maven { url "https://raw.githubusercontent.com/placed/android-placed-sdk/master/repository" }
+            maven { url "https://raw.githubusercontent.com/placed/android-placed-sdk/master/repository" }
+        }
     }
-}
-```
+    ```
 
 2. Add the following to your **app** `build.gradle` file:
 
-```
-dependencies {
-    ...
+    ```
+    dependencies {
+        ...
 
-    compile 'com.placed.client:android-persistent-sdk:1.30'
-}
-```
+        compile 'com.placed.client:android-persistent-sdk:1.30'
+    }
+    ```
+
+3. If you use ProGuard, add the following to your `proguard-rules.pro` file:
+
+    ```
+    # Retrofit
+    # Taken from https://square.github.io/retrofit/
+    -dontnote retrofit2.Platform
+    -dontnote retrofit2.Platform$IOS$MainThreadExecutor
+    -dontwarn retrofit2.Platform$Java8
+    -keepattributes Signature
+    -keepattributes Exceptions
+    -keepclasseswithmembers class * {
+        @retrofit2.http.* <methods>;
+    }
+
+    # OkHttp
+    -dontwarn com.squareup.okhttp.**
+    -dontwarn okio.Okio
+    -dontwarn okio.DeflaterSink
+    -dontwarn java.nio.file.*
+    -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+    # Placed
+    -keep class com.placed.client.android.DTOModel {
+        *;
+    }
+    -keep class * extends com.placed.client.android.DTOModel {
+        <fields>;
+    }
+    ```
   
 ### Configuration
 * Add the application key provided to you by Placed in the application tag of your **AndroidManifest.xml**.
@@ -137,4 +167,3 @@ This method is used for custom integrations with Placed. If you have questions p
   
 `static void logDemographics(Context context, String jsonString, String source, String version)`  
 This method is used for custom integrations with Placed. If you have questions please inquire with your contact at Placed.  
-

--- a/SampleApp/app/build.gradle
+++ b/SampleApp/app/build.gradle
@@ -17,6 +17,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    lintOptions {
+        lintConfig file("lint.xml")
+    }
 }
 
 dependencies {

--- a/SampleApp/app/build.gradle
+++ b/SampleApp/app/build.gradle
@@ -26,5 +26,8 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.placed.client:android-persistent-sdk:1.30'
+
+    // Use the latest version of the Placed SDK
+    // noinspection AndroidLintGradleDynamicVersion
+    compile 'com.placed.client:android-persistent-sdk:1.+'
 }

--- a/SampleApp/app/build.gradle
+++ b/SampleApp/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.placed.android.sampleapp"

--- a/SampleApp/app/lint.xml
+++ b/SampleApp/app/lint.xml
@@ -1,0 +1,6 @@
+<lint>
+    <issue id="InvalidPackage">
+        <ignore regexp=".*okio.*" />
+        <ignore regexp=".*retrofit.*" />
+    </issue>
+</lint>

--- a/SampleApp/app/proguard-rules.pro
+++ b/SampleApp/app/proguard-rules.pro
@@ -15,29 +15,3 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
-
-# Retrofit
-# Taken from https://square.github.io/retrofit/
--dontnote retrofit2.Platform
--dontnote retrofit2.Platform$IOS$MainThreadExecutor
--dontwarn retrofit2.Platform$Java8
--keepattributes Signature
--keepattributes Exceptions
--keepclasseswithmembers class * {
-    @retrofit2.http.* <methods>;
-}
-
-# OkHttp
--dontwarn com.squareup.okhttp.**
--dontwarn okio.Okio
--dontwarn okio.DeflaterSink
--dontwarn java.nio.file.*
--dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
-
-# Placed
--keep class com.placed.client.android.DTOModel {
-    *;
-}
--keep class * extends com.placed.client.android.DTOModel {
-    <fields>;
-}

--- a/SampleApp/app/proguard-rules.pro
+++ b/SampleApp/app/proguard-rules.pro
@@ -15,3 +15,29 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# Retrofit
+# Taken from https://square.github.io/retrofit/
+-dontnote retrofit2.Platform
+-dontnote retrofit2.Platform$IOS$MainThreadExecutor
+-dontwarn retrofit2.Platform$Java8
+-keepattributes Signature
+-keepattributes Exceptions
+-keepclasseswithmembers class * {
+    @retrofit2.http.* <methods>;
+}
+
+# OkHttp
+-dontwarn com.squareup.okhttp.**
+-dontwarn okio.Okio
+-dontwarn okio.DeflaterSink
+-dontwarn java.nio.file.*
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Placed
+-keep class com.placed.client.android.DTOModel {
+    *;
+}
+-keep class * extends com.placed.client.android.DTOModel {
+    <fields>;
+}


### PR DESCRIPTION
Adding Retrofit and OkHttp proguard rules for affiliate apps. These are general rules that are taken from the respective libraries' websites.

Also, since we're now using GSON's automatic serialization of POJOs, we need to make sure any class that extends `DTOModel` retains its fields.

Related SDK PR: https://github.com/sewichi/sewichi-agent/pull/135